### PR TITLE
fixing bug which omits last note in latex output

### DIFF
--- a/fieldmove_notes_merger.py
+++ b/fieldmove_notes_merger.py
@@ -171,7 +171,7 @@ def bold(string):
 # note that certain special characters need special treatment, otherwise LaTeX will fail to compile.
 body = ''
 
-for i in range(filtered_notes.shape[0]-1):
+for i in range(filtered_notes.shape[0]):
     entry = ''
 
     entry += r'\hline' + '\n'


### PR DESCRIPTION
@Swanson-Hysell noticed this when helping EPS 118 students with their assignment